### PR TITLE
Update Django TIME_ZONE setting to use IANA timezone

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -168,7 +168,7 @@ LANGUAGES = [
 
 LOCALE_PATHS = [os.path.join(BASE_DIR, "locale")]
 
-TIME_ZONE = "Brazil/East"
+TIME_ZONE = "America/Sao_Paulo"
 
 USE_I18N = True
 


### PR DESCRIPTION
## Summary
Updated the Django `TIME_ZONE` setting to use the standard IANA timezone identifier instead of a deprecated timezone name.

## Changes
- Changed `TIME_ZONE` from `"Brazil/East"` to `"America/Sao_Paulo"` in `web/settings.py`

## Details
The `Brazil/East` timezone identifier is deprecated and no longer recommended. The change to `America/Sao_Paulo` uses the proper IANA timezone database identifier for the same timezone (UTC-3, with daylight saving time adjustments). This ensures better compatibility with modern timezone databases and follows Django best practices for timezone configuration.

https://claude.ai/code/session_01DRRkE5obJ96qzFmRCnSbgF