### PR TITLE
Add Docker image build and publish workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,60 @@
+name: Build and publish Docker image
+
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types:
+      - completed
+    branches: ["master"]
+
+concurrency:
+  group: build-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ github.event.workflow_run.head_branch }}
+            type=raw,value=${{ github.event.workflow_run.head_sha }}
+            type=raw,value=latest,enable=${{ github.event.workflow_run.head_branch == 'master' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically build and publish Docker images to the GitHub Container Registry (GHCR) when tests pass on the master branch.

## Key Changes
- Added `.github/workflows/docker.yml` workflow that:
  - Triggers on successful completion of the Test workflow on the master branch
  - Uses Docker Buildx to build images with GitHub Actions cache support
  - Authenticates with GHCR using the repository token
  - Tags images with the branch name, commit SHA, and "latest" tag (for master branch only)
  - Pushes built images to `ghcr.io/<repository>`
  - Implements concurrency controls to cancel in-progress builds when new commits are pushed

## Implementation Details
- The workflow only runs when the preceding Test workflow completes successfully
- Images are tagged with:
  - Branch name (e.g., `master`)
  - Full commit SHA for precise version tracking
  - `latest` tag (only when building from master branch)
- Uses GitHub Actions cache for faster subsequent builds
- Checks out the exact commit SHA from the triggering workflow run to ensure consistency

https://claude.ai/code/session_01WiTqFJtijqmSvbcmthCJHk