### PR TITLE
Use short SHA for Docker image tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,12 +28,6 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Compute short SHA
-        id: shortsha
-        env:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-        run: echo "sha=${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -51,7 +45,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ github.event.workflow_run.head_branch }}
-            type=raw,value=${{ steps.shortsha.outputs.sha }}
+            type=sha,prefix=
             type=raw,value=latest,enable=${{ github.event.workflow_run.head_branch == 'master' }}
 
       - name: Build and push Docker image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      - name: Compute short SHA
+        id: shortsha
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: echo "sha=${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -45,7 +51,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ github.event.workflow_run.head_branch }}
-            type=raw,value=${{ github.event.workflow_run.head_sha }}
+            type=raw,value=${{ steps.shortsha.outputs.sha }}
             type=raw,value=latest,enable=${{ github.event.workflow_run.head_branch == 'master' }}
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary
Updated the Docker workflow to use shortened commit SHAs (7 characters) for image tags instead of full-length SHAs, improving readability and consistency with common Git practices.

## Changes
- Added a new step to compute the short SHA (first 7 characters) from the full commit SHA
- Updated the Docker image tagging configuration to use the computed short SHA instead of the full SHA
- The short SHA is now used as a tag alongside the branch name and latest tags

## Implementation Details
- The short SHA is computed using bash string slicing (`${HEAD_SHA:0:7}`) and stored as a step output
- This makes Docker image tags more concise and user-friendly while maintaining uniqueness for practical purposes
- The change maintains all existing tagging behavior (branch name and latest tags) while only modifying the commit SHA tag format

https://claude.ai/code/session_01WiTqFJtijqmSvbcmthCJHk