### PR TITLE
Increase message body max length to 7000 chars

### DIFF
--- a/web/foi_requests/forms.py
+++ b/web/foi_requests/forms.py
@@ -13,7 +13,7 @@ class MessageForm(ModelForm):
         ]
 
     summary = CharField()
-    body = CharField(min_length=55, max_length=2000, widget=Textarea)
+    body = CharField(min_length=55, max_length=7000, widget=Textarea)
 
     def __init__(self, *args, **kwargs):
         super(MessageForm, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Raises the maximum length of an inforequest's message body from 2000 to 7000 characters.

`MessageForm.body` is the single place this limit is defined — Django derives the rendered `<textarea maxlength>` from the same field, and the underlying `Message.body` model field is a `TextField` with no length cap. No other occurrence of the old value exists in the codebase.

Verified the rendered widget picks up the new value:

```
<textarea name="body" cols="40" rows="10" maxlength="7000" minlength="55" required id="id_body">
```

The minimum length (55) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)