### PR TITLE
Reduce info request max length to 5000 chars

### DIFF
--- a/web/foi_requests/forms.py
+++ b/web/foi_requests/forms.py
@@ -13,7 +13,7 @@ class MessageForm(ModelForm):
         ]
 
     summary = CharField()
-    body = CharField(min_length=55, max_length=7000, widget=Textarea)
+    body = CharField(min_length=55, max_length=5000, widget=Textarea)
 
     def __init__(self, *args, **kwargs):
         super(MessageForm, self).__init__(*args, **kwargs)


### PR DESCRIPTION
## Summary

- reduce the info request body maximum length from 7,000 to 5,000 characters

## Validation

- pre-commit hooks passed